### PR TITLE
Fix keyboard input state handling to prevent key press overwrites when space key is still pressed

### DIFF
--- a/packages/viverse/src/input/keyboard.ts
+++ b/packages/viverse/src/input/keyboard.ts
@@ -28,7 +28,7 @@ export class LocomotionKeyboardInput implements Input {
         const now = performance.now() / 1000
         if (state == null) {
           this.keyState.set(event.code, (state = { pressTime: now }))
-        } else {
+        } else if (state.releaseTime != null && state.releaseTime > (state.pressTime ?? 0)) {
           state.pressTime = now
         }
       },


### PR DESCRIPTION
When i tried the example "Frist Person"

`  
      <SimpleCharacter
        model={false}
        input={[LocomotionKeyboardInput, PointerLockInput]}
        cameraBehavior={FirstPersonCharacterCameraBehavior}
      />
`
jump hold the space & keep pressing,then camera will jump super high
<img width="3840" height="2088" alt="image" src="https://github.com/user-attachments/assets/bd85118e-b785-4803-8d27-9bf770f12895" />

