### PR TITLE
Allow extend `LocomotionKeyboardInput`

### DIFF
--- a/packages/viverse/src/input/keyboard.ts
+++ b/packages/viverse/src/input/keyboard.ts
@@ -9,15 +9,18 @@ import {
   RunField,
 } from './index.js'
 
-const MoveForwardKeys = ['KeyW']
-const MoveBackwardKeys = ['KeyS']
-const MoveLeftKeys = ['KeyA']
-const MoveRightKeys = ['KeyD']
-const RunKeys = ['ShiftRight', 'ShiftLeft']
+const defaultKeymapping = {
+  moveForward: ['KeyW'],
+  moveBackward: ['KeyS'],
+  moveLeft: ['KeyA'],
+  moveRight: ['KeyD'],
+  run: ['ShiftRight', 'ShiftLeft']
+}
 
 export class LocomotionKeyboardInput implements Input {
   private readonly abortController = new AbortController()
   private readonly keyState = new Map<string, { pressTime?: number; releaseTime?: number }>()
+  protected keyMapping = defaultKeymapping
 
   constructor(domElement: HTMLElement) {
     domElement.tabIndex = 0
@@ -66,19 +69,19 @@ export class LocomotionKeyboardInput implements Input {
     let keys: Array<string> | undefined
     switch (field) {
       case MoveForwardField:
-        keys = MoveForwardKeys
+        keys = this.keyMapping.moveForward
         break
       case MoveBackwardField:
-        keys = MoveBackwardKeys
+        keys = this.keyMapping.moveBackward
         break
       case MoveLeftField:
-        keys = MoveLeftKeys
+        keys = this.keyMapping.moveLeft
         break
       case MoveRightField:
-        keys = MoveRightKeys
+        keys = this.keyMapping.moveRight
         break
       case RunField:
-        keys = RunKeys
+        keys = this.keyMapping.run
         break
     }
     if (keys == null) {


### PR DESCRIPTION

This PR introduces a conceptual approach to override and extend the default key mappings for LocomotionKeyboardInput, aiming to address [issue #4](https://github.com/pmndrs/viverse/issues/4) — support for customizable keyboard inputs.

Currently, the input system tightly couples the instantiation of inputs with the injection of a domElement:
https://github.com/pmndrs/viverse/blob/934e73b59938f83771762648a515a4c74176d9e9/packages/viverse/src/input/index.ts#L6

Because of that, it’s not currently possible to easily pass additional configuration (like key mappings) into input classes.


With this PR, you can now override the key mappings by subclassing:

```tsx
const keymapping = {
  moveForward: ['KeyW', 'ArrowUp'],
  moveBackward: ['KeyS', 'ArrowDown'],
  moveLeft: ['KeyA', 'ArrowLeft'],
  moveRight: ['KeyD', 'ArrowRight'],
  run: ['ShiftRight', 'ShiftLeft'],
};

class MyCustomKeybindings extends LocomotionKeyboardInput {
  this.keyMapping = keymapping;
}

<SimpleCharacter input={[MyCustomKeybindings, PointerLockInput]} />;
```

My preferred API would allow inline configuration without subclassing:

```tsx
<SimpleCharacter input={[LocomotionKeyboardInput(keymapping), PointerLockInput]} />;
```

However, this isn’t currently possible because `LocomotionKeyboardInput` is constructed with a `domElement`, which is injected internally. To support the above, we’d need to either:
	•	Refactor how inputs are constructed (e.g., use a factory pattern or deferred instantiation)
	•	Or allow inputs to optionally accept config up front and receive the domElement later

This is an early idea, and I don't think this is the right direction (+ I haven't tested it). Would love thoughts on what I should do - because I'm hesitant to refactor the Input class to just to support this config.

Would it make sense to expose a new, more flexible version of `LocomotionKeyboardInput` (e.g. `ConfigurableKeyboardInput`)?

What do you think?