### PR TITLE
docs: Add missing 'type: vrm' to custom model example

### DIFF
--- a/docs/tutorials/custom-models-and-animations.mdx
+++ b/docs/tutorials/custom-models-and-animations.mdx
@@ -15,6 +15,7 @@ export function MyCharacter() {
   return (
     <SimpleCharacter
       model={{
+        type: 'vrm',
         url: '/path/to/your-model.vrm',
         castShadow: true,
         receiveShadow: true


### PR DESCRIPTION
Hi! I'm trying to use a custom VRM model following the documentation, but I found that the code example was missing the `type: 'vrm'` property. Without it, the model doesn't seem to be recognized correctly.

This pull request adds the missing property to the example code.

**Before:**
```tsx
<SimpleCharacter
  model={{
    url: '/path/to/your-model.vrm',
    castShadow: true,
    receiveShadow: true
  }}
/>
```

**After:**
```tsx
<SimpleCharacter
  model={{
    type: 'vrm',
    url: '/path/to/your-model.vrm',
    castShadow: true,
    receiveShadow: true
  }}
/>
```

Now, users can copy-paste the example and have it work as expected.
Thank you for creating this great library!