### PR TITLE
perf: parse each animation file once across characters

### DIFF
--- a/packages/viverse/src/animation/index.ts
+++ b/packages/viverse/src/animation/index.ts
@@ -253,6 +253,24 @@ const gltfLoader = new GLTFLoader()
 const fbxLoader = new FBXLoader()
 const bvhLoader = new BVHLoader()
 
+// Animation files are fetched and parsed once per session — three.js caches
+// neither (THREE.Cache is off and holds bytes, not parse results), so without
+// this every character re-parsed every clip file. The pipeline below mutates
+// the parsed clip and resolves rest transforms against the clip's scene, so
+// consumers receive clones and the cached originals stay pristine. Failed
+// loads are evicted and retried.
+const files = new Map<string, Promise<unknown>>()
+
+function cached<T>(key: string, load: () => Promise<T>): Promise<T> {
+  let entry = files.get(key) as Promise<T> | undefined
+  if (entry == null) {
+    entry = load()
+    files.set(key, entry)
+    void entry.catch(() => files.delete(key))
+  }
+  return entry
+}
+
 export async function loadCharacterAnimation(
   model: CharacterModel,
   url: string | DefaultUrl,
@@ -291,29 +309,30 @@ export async function loadCharacterAnimation(
       )
     }
   }
+  const fileUrl = url
   switch (type) {
     case 'gltf': {
-      const { animations, scene } = await gltfLoader.loadAsync(url)
-      clips = animations
-      clipScene = scene
+      const { animations, scene } = await cached(`gltf:${fileUrl}`, () => gltfLoader.loadAsync(fileUrl))
+      clips = animations.map((animation) => animation.clone())
+      clipScene = scene.clone(true)
       break
     }
     case 'fbx': {
-      const scene = await fbxLoader.loadAsync(url)
-      clips = scene.animations
-      clipScene = scene
+      const scene = await cached(`fbx:${fileUrl}`, () => fbxLoader.loadAsync(fileUrl))
+      clips = scene.animations.map((animation) => animation.clone())
+      clipScene = scene.clone(true)
       break
     }
     case 'bvh': {
-      const { clip, skeleton } = await bvhLoader.loadAsync(url)
-      clips = [clip]
+      const { clip } = await cached(`bvh:${fileUrl}`, () => bvhLoader.loadAsync(fileUrl))
+      clips = [clip.clone()]
       boneMap ??= bvhBoneMap
       break
     }
     case 'mixamo': {
-      const scene = await fbxLoader.loadAsync(url)
-      clips = scene.animations
-      clipScene = scene
+      const scene = await cached(`fbx:${fileUrl}`, () => fbxLoader.loadAsync(fileUrl))
+      clips = scene.animations.map((animation) => animation.clone())
+      clipScene = scene.clone(true)
       boneMap ??= mixamoBoneMap
       break
     }

--- a/packages/viverse/src/model/index.ts
+++ b/packages/viverse/src/model/index.ts
@@ -75,31 +75,36 @@ export async function loadCharacterModel(
 ): Promise<CharacterModel> {
   let result: Omit<CharacterModel, 'mixer' | 'currentAnimations'>
 
+  let resolvedUrl: string
   if (url == null) {
     //prepare loading the default model
     type = 'gltf'
-    url = (await import('../assets/mannequin.js')).url
+    resolvedUrl = (await import('../assets/mannequin.js')).url
     boneRotationOffset = new Quaternion().setFromEuler(new Euler(Math.PI / 2, 0, Math.PI / 2, 'ZYX'))
+  } else {
+    resolvedUrl = url
   }
 
   if (type == null) {
-    if (url.endsWith('.gltf') || url.endsWith('.glb')) {
+    if (resolvedUrl.endsWith('.gltf') || resolvedUrl.endsWith('.glb')) {
       type = 'gltf'
     }
-    if (url.endsWith('.vrm')) {
+    if (resolvedUrl.endsWith('.vrm')) {
       type = 'vrm'
     }
     if (type == null) {
-      throw new Error(`Unable to infer model type from url "${url}. Please specify the type of the model manually."`)
+      throw new Error(
+        `Unable to infer model type from url "${resolvedUrl}. Please specify the type of the model manually.`,
+      )
     }
   }
 
   switch (type) {
     case 'vrm':
-      result = await loadVrmCharacterModel(url)
+      result = await loadVrmCharacterModel(resolvedUrl)
       break
     case 'gltf':
-      result = await loadGltfCharacterModel(url, useDraco)
+      result = await loadGltfCharacterModel(resolvedUrl, useDraco)
       break
   }
   result.boneRotationOffset = boneRotationOffset


### PR DESCRIPTION
## Motivation

`loadCharacterAnimation` re-fetches and re-parses every animation file on every call. three.js does not cover this: `THREE.Cache` is disabled by default and stores raw bytes, `FileLoader` only dedupes concurrent in-flight fetches, and `GLTFLoader.parse()` re-runs regardless — so a scene with several characters repeats identical parses for every clip on boot.

## Change

A session-lifetime promise cache (one `Map`, one 10-line helper): each animation file loads once per url. The pipeline mutates the parsed clip *and* resolves rest transforms against the clip scene, so callers receive clones — the cached originals stay pristine and every character owns its clip exactly as before. Rejected loads are evicted so transient failures retry. VRMA stays per-call (VRM-specific path, different mutation semantics). The unused `skeleton` binding in the bvh case is dropped.

Per-character **retargeting is deliberately not cached**: measured at milliseconds per clip, the duplicated cost was always fetch+parse. Keeps the change to one cache — no new fields, no new dependencies, no shared-clip invariants for consumers.

Net: **+30/−11 in one file**, plus a separate one-commit fix for the pre-existing strict-TS build error in `model/index.ts` (`tsc -p tsconfig.build.json` fails on main without it).

## Verification

`pnpm build`, `pnpm check:prettier`, `pnpm check:eslint` all pass (build fails on main; see the fix commit). Single-character behavior unchanged; the first-load path is the previous code plus one clone per clip/scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)